### PR TITLE
do not use default system prompt

### DIFF
--- a/samples/ios/phi.engine.sample/phi.engine.sample/AiViewModel.swift
+++ b/samples/ios/phi.engine.sample/phi.engine.sample/AiViewModel.swift
@@ -20,7 +20,7 @@ class Phi3ViewModel: ObservableObject {
     init() {
         let inferenceOptionsBuilder = InferenceOptionsBuilder()
         try! inferenceOptionsBuilder.withTemperature(temperature: 0.9)
-        try! inferenceOptionsBuilder.withSeed(seed: 146628346)
+        try! inferenceOptionsBuilder.withSeed(seed: 146628345)
         self.inferenceOptions = try! inferenceOptionsBuilder.build()
     }
     
@@ -34,7 +34,7 @@ class Phi3ViewModel: ObservableObject {
         try! engineBuilder.withModelProvider(modelProvider: modelProvider)
         try! engineBuilder.withEventHandler(eventHandler: BoxedPhiEventHandler(handler: ModelEventsHandler(parent: self)))
         
-        self.engine = try! engineBuilder.buildStateful(cacheDir: FileManager.default.temporaryDirectory.path(), systemInstruction: "You are a sports store agent. you speak only about sports equipment. Be brief, direct and polite.")
+        self.engine = try! engineBuilder.buildStateful(cacheDir: FileManager.default.temporaryDirectory.path(), systemInstruction: "You are a hockey wise old man. Share your wisdom briefly like an oracle. Be brief and to the point.")
         DispatchQueue.main.async {
             self.isLoadingEngine = false
             self.isReady = true

--- a/strathweb-phi-engine/src/engine.rs
+++ b/strathweb-phi-engine/src/engine.rs
@@ -634,9 +634,14 @@ impl PhiEngine {
             })
             .collect::<String>();
 
-        let system_instruction = conversation_context.system_instruction.clone().unwrap_or("You are a helpful assistant that answers user questions. Be short and direct in your answers.".to_string());
-
-        let prompt_with_history = format!("<|system|>\n{}<|end|>\n<|assistant|>Understood, I will adhere to these instructions<|end|>{}\n<|assistant|>\n", system_instruction, history_prompt);
+        let prompt_with_history = {
+            // if system instruction is there, use it, otherwise construct prompt without system instruction
+            if let Some(system_instruction) = conversation_context.system_instruction.clone() {
+                format!("<|system|>{}<|end|>{}\n<|assistant|>\n", system_instruction, history_prompt)
+            } else {
+                format!("{}\n<|assistant|>\n", history_prompt)
+            }
+        };
 
         let mut pipeline = TextGenerator::new(
             &self.model,


### PR DESCRIPTION
From now on, we will no longer inject a default system prompt. Instead, if none is provided we will simply omit it. This is a much better default and aligns with how most people expect the models to work.